### PR TITLE
PLAT-71: Allow define one optional volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Input variables
  * `memory`- (string) OPTIONAL - The memory limit for this container definition
  * `env`: (map) OPTIONAL - map with environment variables
  * `metadata`: (map) OPTIONAL - Set of metadata for this container. It will be passed as environment variables (key uppercased) and labels.
+ * `mountpoint`: (map) OPTIONAL - Configuration of one mountpoint for this volume. Map with the values `sourceVolume`, `containerPath` and (optional) `readOnly` .
 
 Usage
 -----
@@ -21,22 +22,28 @@ Usage
 ```hcl
 module "container_defintions" {
   source = "github.com/mergermarket/tf_ecs_container_definitions"
-  
+
   name           = "some-app"
   image          = "repo/image"
   container_port = "8080"
   cpu            = 1024
   memory         = 256
-  
+
   container_env = {
     VAR1 = "value1"
     VAR2 = "value2"
   }
-  
+
   metadata = {
     "label1" = "label.one"
     "label2" = "label.two"
-  } 
+  }
+
+  mountpoint = {
+	sourceVolume = 'data_volume',
+    containerPath = '/mnt/data',
+    readOnly = true
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ module "container_defintions" {
   }
 
   mountpoint = {
-	sourceVolume = 'data_volume',
+    sourceVolume  = 'data_volume',
     containerPath = '/mnt/data',
-    readOnly = true
+    readOnly      = true
   }
 }
 ```

--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -17,5 +17,15 @@
       { "name": "STATSD_PORT", "value": "8125" },
       { "name": "STATSD_ENABLED", "value": "true" }
     ],
-    "dockerLabels": ${labels}
+    "dockerLabels": ${labels},
+    "mountPoints": [
+      ${mountpoint_sourceVolume == "none" ? "" :
+          format(
+            "{ \"sourceVolume\": \"%s\", \"containerPath\": \"%s\", \"readOnly\": %s }",
+            mountpoint_sourceVolume,
+            mountpoint_containerPath,
+            mountpoint_readOnly
+          )
+      }
+    ]
   }

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,10 @@ data "template_file" "container_definitions" {
     },"
 
     labels = "${jsonencode(var.metadata)}"
+
+    mountpoint_sourceVolume = "${lookup(var.mountpoint, "sourceVolume", "none")}"
+    mountpoint_containerPath = "${lookup(var.mountpoint, "containerPath", "none")}"
+    mountpoint_readOnly = "${lookup(var.mountpoint, "readOnly", false)}"
   }
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -27,9 +27,9 @@ data "template_file" "container_definitions" {
 
     labels = "${jsonencode(var.metadata)}"
 
-    mountpoint_sourceVolume = "${lookup(var.mountpoint, "sourceVolume", "none")}"
+    mountpoint_sourceVolume  = "${lookup(var.mountpoint, "sourceVolume", "none")}"
     mountpoint_containerPath = "${lookup(var.mountpoint, "containerPath", "none")}"
-    mountpoint_readOnly = "${lookup(var.mountpoint, "readOnly", false)}"
+    mountpoint_readOnly      = "${lookup(var.mountpoint, "readOnly", false)}"
   }
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,9 @@ variable "metadata" {
   type        = "map"
   default     = {}
 }
+
+variable "mountpoint" {
+  description = "Mountpoint map with 'sourceVolume' and 'containerPath' and 'readOnly' (optional)."
+  type        = "map"
+  default     = {}
+}


### PR DESCRIPTION
For some cases and workloads we need to pass some mountpoints to the container
definition. The mountpoints are passed as a list of maps in the json under
`mountPoints`[1].

In the related modules tf_task_definition, we added logic to define one
optional volume[2], and here we allow to specify the mounpoint for that
volume.

The mountpoint is defined as a map with the keys `sourceVolume`,
`containerPath` and (optional) `readOnly` .

[1] http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_storage
[2] https://github.com/mergermarket/tf_ecs_task_definition/pull/3