### PR TITLE
Deprecate the metdata parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,14 +12,11 @@ data "template_file" "container_definitions" {
     container_env = "${
       join (
         format(",\n      "),
-        concat(
-          null_resource._jsonencode_container_env.*.triggers.entries,
-          null_resource._jsonencode_metadata_env.*.triggers.entries
-        )
+        null_resource._jsonencode_container_env.*.triggers.entries
       )
     }"
 
-    labels = "${jsonencode(var.metadata)}"
+    labels = "${jsonencode(var.labels)}"
 
     mountpoint_sourceVolume  = "${lookup(var.mountpoint, "sourceVolume", "none")}"
     mountpoint_containerPath = "${lookup(var.mountpoint, "containerPath", "none")}"
@@ -27,8 +24,7 @@ data "template_file" "container_definitions" {
   }
 
   depends_on = [
-    "null_resource._jsonencode_container_env",
-    "null_resource._jsonencode_metadata_env",
+    "null_resource._jsonencode_container_env"
   ]
 }
 
@@ -53,18 +49,3 @@ resource "null_resource" "_jsonencode_container_env" {
   count = "${length(var.container_env)}"
 }
 
-# JSON snippet with the list of labels
-resource "null_resource" "_jsonencode_metadata_env" {
-  triggers {
-    entries = "${
-      jsonencode(
-        map(
-          "name", upper(element(keys(var.metadata), count.index)),
-          "value", element(values(var.metadata), count.index),
-          )
-      )
-    }"
-  }
-
-  count = "${length(var.metadata)}"
-}

--- a/test/test_container_definition.py
+++ b/test/test_container_definition.py
@@ -88,7 +88,7 @@ class TestContainerDefinition(unittest.TestCase):
 
         assert {'containerPort': 8001} in definition['portMappings']
 
-    def test_metadata(self):
+    def test_labels(self):
         # Given
         variables = {
             'name': 'test-' + str(int(time.time() * 1000)),
@@ -98,7 +98,7 @@ class TestContainerDefinition(unittest.TestCase):
             'container_port': 8001
         }
         varsmap = {
-            'metadata': {
+            'labels': {
                 'label_key_1': 'label_value_1',
                 'label_key_2': 'label_value_2',
             }
@@ -111,14 +111,14 @@ class TestContainerDefinition(unittest.TestCase):
         assert {
             'name': 'LABEL_KEY_1',
             'value': 'label_value_1'
-            } in definition['environment']
+            } not in definition['environment']
         assert {
             'name': 'LABEL_KEY_2',
             'value': 'label_value_2'
-            } in definition['environment']
+            } not in definition['environment']
 
-        for key in varsmap['metadata']:
-            assert varsmap['metadata'][key] in definition['dockerLabels'][key]
+        for key in varsmap['labels']:
+            assert varsmap['labels'][key] in definition['dockerLabels'][key]
 
     def test_container_env(self):
         # given

--- a/variables.tf
+++ b/variables.tf
@@ -27,8 +27,14 @@ variable "container_env" {
   default     = {}
 }
 
+variable "labels" {
+  description = "Labels to be applied to the docker container"
+  type        = "map"
+  default     = {}
+}
+
 variable "metadata" {
-  description = "Metadata for this image. Will be passed as environment variables and labels"
+  description = "DEPRECATED - values passed to this variable will be ignored"
   type        = "map"
   default     = {}
 }


### PR DESCRIPTION
Separate out parameters for contianer env and labels since it's not
certain that users will always want to set both via one parameter. This is
(AFAICT) not used yet.