### PR TITLE
Remove null resources and counts

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -9,9 +9,7 @@
     ],
     "cpu": ${cpu},
     "memory": ${mem},
-    "environment": [
-      ${container_env}
-    ],
+    "environment": ${container_env},
     "dockerLabels": ${labels},
     "mountPoints": [
       ${mountpoint_sourceVolume == "none" ? "" :


### PR DESCRIPTION
These were causing issues when the incoming environment was based on
dynamic values that couldn't be calculated during the plan. This
replaces it with use of python to transform the json from a simple
dictionary to the format expected in the "environment" field of the
container definition json.