### PR TITLE
Make it possible to override port mappings

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -2,11 +2,7 @@
     "name": "${container_name}",
     "essential": true,
     "image": "${image}",
-    "portMappings": [
-      {
-        "containerPort": ${container_port}
-      }
-    ],
+    "portMappings": ${port_mappings},
     "cpu": ${cpu},
     "memory": ${mem},
     "environment": ${container_env},

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,11 @@ data "template_file" "container_definitions" {
   vars {
     image              = "${var.image}"
     container_name     = "${var.name}"
-    container_port     = "${var.container_port}"
+    port_mappings      = "${
+      var.port_mappings == "" ?
+        format("[ { \"containerPort\": %s } ]", var.container_port) :
+        var.port_mappings
+    }"
     cpu                = "${var.cpu}"
     mem                = "${var.memory}"
     container_env      = "${data.external.encode_env.result["env"]}"

--- a/test/test_container_definition.py
+++ b/test/test_container_definition.py
@@ -90,6 +90,25 @@ class TestContainerDefinition(unittest.TestCase):
         assert {'softLimit': 1000, 'name': 'nofile', 'hardLimit': 65535} in definition['ulimits']
         assert {'containerPort': 8001} in definition['portMappings']
 
+    def test_override_port_mappings(self):
+        # Given
+        variables = {
+            'name': 'test-' + str(int(time.time() * 1000)),
+            'image': '123',
+            'cpu': 1024,
+            'memory': 1024,
+            'nofile_soft_ulimit': 1000
+        }
+        varsmap = {
+            'port_mappings': '[{"containerPort":7654}]'
+        }
+
+        # when
+        definition = self._apply_and_parse(variables, varsmap)
+
+        # then
+        assert [ { 'containerPort': 7654 } ] == definition['portMappings']
+        
     def test_labels(self):
         # Given
         variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,9 @@ variable "mountpoint" {
   type        = "map"
   default     = {}
 }
+
+variable "port_mappings" {
+  description = "JSON document containing an array of port mappings for the container defintion - if set container_port is ignored (optional)."
+  default     = ""
+  type        = "string"
+}


### PR DESCRIPTION
This will allow a port mapping with an additional JMX port to be passed
in (required to support confluence).