### PR TITLE
DO NOT MERGE YET - Turn on init process

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -23,5 +23,8 @@
         "softLimit": ${nofile_soft_ulimit},
         "hardLimit": 65535
       }
-    ]
+    ],
+    "linuxParameters": {
+      "initProcessEnabled": true
+    }
   }


### PR DESCRIPTION
This enables a tini init process within the container, which runs as PID 1 and does the stuff that a PID 1 should do - reaping zombie processes, forwarding signals to the entrypoint and exiting with the status of the entrypoint. Not running the entrypoint as PID one also means it has the default signal handlers installed so responds to SIGINT and SIGTERM as you would expect (by exiting immediately) without having to add these handlers manually. This isn't entirely backwards compatible, so some care should be taken when rolling it out.