### PR TITLE
Enable the init process in containers

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -23,5 +23,6 @@
         "softLimit": ${nofile_soft_ulimit},
         "hardLimit": 65535
       }
-    ]
+    ],
+    "initProcessEnabled": "true"
   }

--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -24,5 +24,7 @@
         "hardLimit": 65535
       }
     ],
-    "initProcessEnabled": "true"
+    "linuxParameters": {
+      "initProcessEnabled": "true"
+    }
   }

--- a/test/test_container_definition.py
+++ b/test/test_container_definition.py
@@ -256,5 +256,5 @@ class TestContainerDefinition(unittest.TestCase):
         definition = self._apply_and_parse(variables, varsmap)
 
         # then
-        assert definition['initProcessEnabled']
+        assert definition['linuxParameters']['initProcessEnabled']
 

--- a/test/test_container_definition.py
+++ b/test/test_container_definition.py
@@ -240,3 +240,21 @@ class TestContainerDefinition(unittest.TestCase):
             'readOnly': True
             }] == definition['mountPoints']
 
+
+    def test_init_process_enabled(self):
+        # given
+        variables = {
+            'name': 'test-' + str(int(time.time() * 1000)),
+            'image': '123',
+            'cpu': 1024,
+            'memory': 1024,
+            'container_port': 8001
+        }
+        varsmap = {}
+
+        # when
+        definition = self._apply_and_parse(variables, varsmap)
+
+        # then
+        assert definition['initProcessEnabled']
+


### PR DESCRIPTION
This ensures that Nodejs processes can be terminated gracefully by ECS.