### PR TITLE
Switch string for boolean

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -25,6 +25,6 @@
       }
     ],
     "linuxParameters": {
-      "initProcessEnabled": "true"
+      "initProcessEnabled": true
     }
   }


### PR DESCRIPTION
Looks like Go can't unmarshall this value as it's the wrong type.