### PR TITLE
Adds back the secrets functionality

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -6,6 +6,7 @@
     "cpu": ${cpu},
     "memory": ${mem},
     "environment": ${container_env},
+    "secrets": ${secrets},
     "dockerLabels": ${labels},
     "mountPoints": [
       ${mountpoint_sourceVolume == "none" ? "" :

--- a/encode_env.py
+++ b/encode_env.py
@@ -1,0 +1,19 @@
+import json
+from sys import stdin
+
+terraform_input = json.loads(stdin.read())
+env = json.loads(terraform_input["env"])
+
+metadata = {
+    key.upper(): value
+    for key, value
+    in json.loads(terraform_input["metadata"]).items()
+}
+
+output = [
+    {"name": key, "value": value}
+    for key, value
+    in list(env.items()) + list(metadata.items())
+]
+
+print(json.dumps({"env": json.dumps(output)}))

--- a/encode_secrets.py
+++ b/encode_secrets.py
@@ -1,0 +1,22 @@
+import json
+from sys import stdin
+
+terraform_input = json.loads(stdin.read())
+secrets = json.loads(terraform_input.get("secrets", "{}"))
+common_secrets = json.loads(terraform_input.get("common_secrets", "{}"))
+
+secrets = [
+    {"name": key, "valueFrom": value}
+    for key, value
+    in list(secrets.items())
+]
+
+common_secrets = [
+    {"name": key, "valueFrom": value}
+    for key, value
+    in list(common_secrets.items())
+]
+
+output = secrets + common_secrets
+
+print(json.dumps({"secrets": json.dumps(output)}))

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "rendered" {
   value = "${data.template_file.container_definitions.rendered}"
 }
+

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3-alpine
 COPY requirements.txt .
 
-ENV TERRAFORM_VERSION=0.9.5
+ENV TERRAFORM_VERSION=0.11.11
 ENV TERRAFORM_ZIP=terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-ENV TERRAFORM_SUM=0cbb5474c76d878fbc99e7705ce6117f4ea0838175c13b2663286a207e38d783
+ENV TERRAFORM_SUM=94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c
 
-RUN apk add -U ca-certificates curl && \
+RUN apk add -U ca-certificates curl gcc musl-dev libffi-dev openssl-dev && \
     cd /tmp && \
     curl -fsSLO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP} && \
     echo "${TERRAFORM_SUM}  /tmp/${TERRAFORM_ZIP}" | sha256sum -c - && \

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -1,0 +1,62 @@
+# configure provider to not try too hard talking to AWS API
+provider "aws" {
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_get_ec2_platforms      = true
+  skip_region_validation      = true
+  skip_requesting_account_id  = true
+  max_retries                 = 1
+  access_key                  = "a"
+  secret_key                  = "a"
+  region                      = "eu-west-1"
+}
+
+# fixture
+module "tf_ecs_container_definition_test" {
+  source             = "../.."
+  cpu                = "${var.cpu}"
+  memory             = "${var.memory}"
+  name               = "${var.name}"
+  image              = "${var.image}"
+  nofile_soft_ulimit = "${var.nofile_soft_ulimit}"
+  container_port     = "${var.container_port}"
+  labels             = "${var.labels}"
+  port_mappings      = "${var.port_mappings}"
+  mountpoint         = "${var.mountpoint}"
+  container_env      = "${var.container_env}"
+  metadata           = "${var.metadata}"
+  team_secrets       = "${var.team_secrets}"
+  common_secrets     = "${var.common_secrets}"
+}
+
+variable "name" {}
+
+variable "image" {}
+
+variable "nofile_soft_ulimit" {
+  default     = "4096"
+}
+
+variable "container_port" { default = "" }
+ 
+variable "labels" { default = {} }
+ 
+variable "port_mappings" { default = "" }
+ 
+variable "mountpoint" { default = {} }
+ 
+variable "container_env" { default = {} }
+ 
+variable "metadata" { default = {} }
+ 
+variable "team_secrets" { default = [] }
+
+variable "common_secrets" { default = [] }
+
+variable "memory" {}
+
+variable "cpu" {}
+
+output "rendered" {
+  value = "${module.tf_ecs_container_definition_test.rendered}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -55,3 +55,13 @@ variable "port_mappings" {
   default     = ""
   type        = "string"
 }
+
+variable "team_secrets" {
+  type = "list"
+  default = []
+}
+
+variable "common_secrets" {
+  type = "list"
+  default = []
+}


### PR DESCRIPTION
This renables "secrets" in the container template after creating a
"no-secrets" branch that people can use that do not pass in execution
roles.

Revert "Revert "Adding secrets to container definition (#12)""

This reverts commit 5ac659cb88a6343d6e2a4449d474f24c9aaba2c1.