### PR TITLE
Add command to task definition

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -5,6 +5,7 @@
     "portMappings": ${port_mappings},
     "cpu": ${cpu},
     "memory": ${mem},
+    "command": ${command},
     "environment": ${container_env},
     "secrets": ${secrets},
     "dockerLabels": ${labels},

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ data "template_file" "container_definitions" {
 
     cpu                = "${var.cpu}"
     mem                = "${var.memory}"
+    command            = "${length(var.command) > 0 ? jsonencode(var.command) : "null"}"
     container_env      = "${data.external.encode_env.result["env"]}"
     secrets            = "${data.external.encode_secrets.result["secrets"]}"
     labels             = "${jsonencode(var.labels)}"

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -13,20 +13,21 @@ provider "aws" {
 
 # fixture
 module "tf_ecs_container_definition_test" {
-  source             = "../.."
-  cpu                = "${var.cpu}"
-  memory             = "${var.memory}"
-  name               = "${var.name}"
-  image              = "${var.image}"
-  nofile_soft_ulimit = "${var.nofile_soft_ulimit}"
-  container_port     = "${var.container_port}"
-  labels             = "${var.labels}"
-  port_mappings      = "${var.port_mappings}"
-  mountpoint         = "${var.mountpoint}"
-  container_env      = "${var.container_env}"
-  metadata           = "${var.metadata}"
-  application_secrets       = "${var.application_secrets}"
-  platform_secrets     = "${var.platform_secrets}"
+  source              = "../.."
+  cpu                 = "${var.cpu}"
+  memory              = "${var.memory}"
+  command             = "${var.command}"
+  name                = "${var.name}"
+  image               = "${var.image}"
+  nofile_soft_ulimit  = "${var.nofile_soft_ulimit}"
+  container_port      = "${var.container_port}"
+  labels              = "${var.labels}"
+  port_mappings       = "${var.port_mappings}"
+  mountpoint          = "${var.mountpoint}"
+  container_env       = "${var.container_env}"
+  metadata            = "${var.metadata}"
+  application_secrets = "${var.application_secrets}"
+  platform_secrets    = "${var.platform_secrets}"
 }
 
 variable "name" {}
@@ -37,7 +38,7 @@ variable "nofile_soft_ulimit" {
   default     = "4096"
 }
 
-variable "container_port" { default = "" }
+variable "container_port" { default = "8080" }
  
 variable "labels" { default = {} }
  
@@ -53,9 +54,11 @@ variable "application_secrets" { default = [] }
 
 variable "platform_secrets" { default = [] }
 
-variable "memory" {}
+variable "memory" { default = "256" }
 
-variable "cpu" {}
+variable "cpu" { default = "64" }
+
+variable "command" { default = [] }
 
 output "rendered" {
   value = "${module.tf_ecs_container_definition_test.rendered}"

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "memory" {
   default     = "256"
 }
 
+variable "command" {
+  description = "The command that is passed to the container"
+  type        = "list"
+  default     = []
+}
+
 variable "nofile_soft_ulimit" {
   description = "The soft ulimit for the number of files in container"
   default     = "4096"


### PR DESCRIPTION
Add `command` to task definition to allow tasks to execute different commands from the originally defined. Just like Docker CMD.

- Add tests
- Tidy up Python test (Pylama)