### PR TITLE
Adding stopTimeout to cointainer definition

### DIFF
--- a/container_definition.json.tmpl
+++ b/container_definition.json.tmpl
@@ -5,7 +5,8 @@
     "portMappings": ${port_mappings},
     "cpu": ${cpu},
     "memory": ${mem},
-    ${memory_reservation == "none" ? "" : format("\"memory_reservation\": %s,", memory_reservation)}
+    ${stop_timeout == "none" ? "" : format("\"stopTimeout\": %s,", stop_timeout)}  
+    ${memory_reservation == "none" ? "" : format("\"memoryReservation\": %s,", memory_reservation)}
     "command": ${command},
     "environment": ${container_env},
     "secrets": ${secrets},

--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,10 @@ data "template_file" "container_definitions" {
     }"
 
     cpu                = "${var.cpu}"
+    stop_timeout       = "${var.stop}"
     mem                = "${var.memory}"
     memory_reservation = "${var.memory_reservation}"
+    stop_timeout       = "${var.stop_timeout}"
     command            = "${length(var.command) > 0 ? jsonencode(var.command) : "null"}"
     container_env      = "${data.external.encode_env.result["env"]}"
     secrets            = "${data.external.encode_secrets.result["secrets"]}"

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,6 @@ data "template_file" "container_definitions" {
     }"
 
     cpu                = "${var.cpu}"
-    stop_timeout       = "${var.stop}"
     mem                = "${var.memory}"
     memory_reservation = "${var.memory_reservation}"
     stop_timeout       = "${var.stop_timeout}"

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -28,6 +28,8 @@ module "tf_ecs_container_definition_test" {
   metadata            = "${var.metadata}"
   application_secrets = "${var.application_secrets}"
   platform_secrets    = "${var.platform_secrets}"
+  stop_timeout        = "${var.stop_timeout}"
+  memory_reservation  = "${var.memory_reservation}"
 }
 
 variable "name" {}
@@ -56,9 +58,13 @@ variable "platform_secrets" { default = [] }
 
 variable "memory" { default = "256" }
 
+variable "memory_reservation" { default = "none" }
+
 variable "cpu" { default = "64" }
 
 variable "command" { default = [] }
+
+variable "stop_timeout" { default = "none" }
 
 output "rendered" {
   value = "${module.tf_ecs_container_definition_test.rendered}"

--- a/test/test_container_definition.py
+++ b/test/test_container_definition.py
@@ -87,6 +87,8 @@ class TestContainerDefinition(unittest.TestCase):
         assert definition['cpu'] == 1024
         assert definition['memory'] == 1024
         assert definition['essential']
+        assert 'stopTimeout' not in definition
+        assert 'memoryReservation' not in definition
 
         assert {
             'softLimit': 1000, 'name': 'nofile',
@@ -282,6 +284,92 @@ class TestContainerDefinition(unittest.TestCase):
         assert definition['cpu'] == 1024
         assert definition['memory'] == 1024
         assert definition['command'] == ["/bin/bash", "-c", "cat"]
+
+    def test_stop_timeout(self):
+        # Given
+        variables = {
+            'name': 'test-' + str(int(time.time() * 1000)),
+            'image': '123',
+            'cpu': 1024,
+            'memory': 1024,
+            'stop_timeout': '120'
+        }
+        varsmap = {
+            'command': ["/bin/bash", "-c", "cat"]
+        }
+
+        # when
+        definition = self._apply_and_parse(variables, varsmap)
+
+        # then
+        assert definition['name'] == variables['name']
+        assert definition['image'] == '123'
+        assert definition['cpu'] == 1024
+        assert definition['memory'] == 1024
+        assert definition['stopTimeout'] == 120
+
+    def test_stop_timeout_not_set(self):
+            # Given
+        variables = {
+            'name': 'test-' + str(int(time.time() * 1000)),
+            'image': '123',
+            'cpu': 1024,
+            'memory': 1024,
+        }
+        varsmap = {}
+
+        # when
+        definition = self._apply_and_parse(variables, varsmap)
+
+        # then
+        assert definition['name'] == variables['name']
+        assert definition['image'] == '123'
+        assert definition['cpu'] == 1024
+        assert definition['memory'] == 1024
+        assert 'stopTimeout' not in definition 
+
+    def test_memory_reservation(self):
+        # Given
+        variables = {
+            'name': 'test-' + str(int(time.time() * 1000)),
+            'image': '123',
+            'cpu': 1024,
+            'memory': 1024,
+            'memory_reservation': '1024'
+        }
+        varsmap = {
+            'command': ["/bin/bash", "-c", "cat"]
+        }
+
+        # when
+        definition = self._apply_and_parse(variables, varsmap)
+
+        # then
+        assert definition['name'] == variables['name']
+        assert definition['image'] == '123'
+        assert definition['cpu'] == 1024
+        assert definition['memory'] == 1024
+        assert definition['memoryReservation'] == 1024
+
+    def test_memory_reservation_not_set(self):
+            # Given
+        variables = {
+            'name': 'test-' + str(int(time.time() * 1000)),
+            'image': '123',
+            'cpu': 1024,
+            'memory': 1024,
+        }
+        varsmap = {}
+
+        # when
+        definition = self._apply_and_parse(variables, varsmap)
+
+        # then
+        assert definition['name'] == variables['name']
+        assert definition['image'] == '123'
+        assert definition['cpu'] == 1024
+        assert definition['memory'] == 1024
+        assert 'memoryReservation' not in definition    
 
     def test_command_empty(self):
         # Given

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,8 @@ variable "platform_secrets" {
   type    = "list"
   default = []
 }
+
+variable "stop_timeout" {
+  description = "The duration is seconds to wait before the container is forcefully killed. Default 30s, max 120s."
+  default     = "none"
+}


### PR DESCRIPTION
Adding stopTimeout to the container definition.

We have increased the timeout, and then our ECS service was able to work without errors with a Network Load Balancer.

We have tested this in aslive: https://jenkins.mergermarket.it/job/c6revolution/job/compliance-internal-api/1277/console.

My forked tf_ecs_service was pointing to this fork.
